### PR TITLE
chore: set pilot CLI to Java 25

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -14,7 +14,8 @@
     "pilot": {
       "script-ref": "https://repo.maven.apache.org/maven2/eu/maveniverse/maven/pilot/pilot-cli/0.2.1/pilot-cli-0.2.1.jar",
       "java-agents": [],
-      "description": "Pilot CLI"
+      "description": "Pilot CLI",
+      "java": "25"
     }
   }
 }


### PR DESCRIPTION
Adds `"java": "25"` to the `pilot` alias in `jbang-catalog.json` so pilot-cli runs with Java 25 by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pilot CLI configuration to specify Java 25 as the required runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->